### PR TITLE
Update create-uami.sh

### DIFF
--- a/automatic/custom-network/private/sh/create-uami.sh
+++ b/automatic/custom-network/private/sh/create-uami.sh
@@ -3,9 +3,9 @@ az identity create \
  --name ${IDENTITY_NAME} \
  --location ${LOCATION}
 
-IDENTITY_CLIENT_ID=$(az identity show --resource-group ${RG_NAME} --name ${IDENTITY_NAME} --query clientId -o tsv)
+IDENTITY_PRINCIPAL_ID=$(az identity show --resource-group ${RG_NAME} --name ${IDENTITY_NAME} --query principalId -o tsv)
 
 az role assignment create \
 --scope "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/virtualNetworks/${VNET_NAME}" \
 --role "Network Contributor" \
---assignee ${IDENTITY_CLIENT_ID}
+--assignee ${IDENTITY_PRINCIPAL_ID}

--- a/automatic/custom-network/public/sh/create-uami.sh
+++ b/automatic/custom-network/public/sh/create-uami.sh
@@ -3,9 +3,9 @@ az identity create \
  --name ${IDENTITY_NAME} \
  --location ${LOCATION}
 
-IDENTITY_CLIENT_ID=$(az identity show --resource-group ${RG_NAME} --name ${IDENTITY_NAME} --query clientId -o tsv)
+IDENTITY_PRINCIPAL_ID=$(az identity show --resource-group ${RG_NAME} --name ${IDENTITY_NAME} --query principalId -o tsv)
 
 az role assignment create \
 --scope "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/virtualNetworks/${VNET_NAME}" \
 --role "Network Contributor" \
---assignee ${IDENTITY_CLIENT_ID}
+--assignee ${IDENTITY_PRINCIPAL_ID}


### PR DESCRIPTION
Updating to use the Identity's principalId instead of clientId, even though the CLI resolves this using the Graph API, for coherence with Bicep.