### PR TITLE
update az role assignment create commands to not require entra sync before they run

### DIFF
--- a/automatic/custom-network/private/sh/create-uami.sh
+++ b/automatic/custom-network/private/sh/create-uami.sh
@@ -8,4 +8,5 @@ IDENTITY_PRINCIPAL_ID=$(az identity show --resource-group ${RG_NAME} --name ${ID
 az role assignment create \
 --scope "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/virtualNetworks/${VNET_NAME}" \
 --role "Network Contributor" \
---assignee ${IDENTITY_PRINCIPAL_ID}
+--assignee-object-id "${IDENTITY_PRINCIPAL_ID}" \
+--assignee-principal-type ServicePrincipal

--- a/automatic/custom-network/public/sh/create-uami.sh
+++ b/automatic/custom-network/public/sh/create-uami.sh
@@ -8,4 +8,5 @@ IDENTITY_PRINCIPAL_ID=$(az identity show --resource-group ${RG_NAME} --name ${ID
 az role assignment create \
 --scope "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/virtualNetworks/${VNET_NAME}" \
 --role "Network Contributor" \
---assignee ${IDENTITY_PRINCIPAL_ID}
+--assignee-object-id "${IDENTITY_PRINCIPAL_ID}" \
+--assignee-principal-type ServicePrincipal


### PR DESCRIPTION
When `az role assignment create --assignee <>` is called, it requires the previously created principal to have synced to Entra in order for it to be looked up.

Using `az role assignment create --assignee-object-id <> --assignee-principal-type ServicePrincipal` skips the lookup.